### PR TITLE
Fix references to numpy.oldnumeric

### DIFF
--- a/oldnumeric/alter_code1.py
+++ b/oldnumeric/alter_code1.py
@@ -138,22 +138,22 @@ def fromstr(filestr):
     savestr = filestr[:]
     filestr = fixtypechars(filestr)
     filestr = fixistesting(filestr)
-    filestr, fromall1 = changeimports(filestr, 'Numeric', 'numpy.oldnumeric')
-    filestr, fromall1 = changeimports(filestr, 'multiarray', 'numpy.oldnumeric')
-    filestr, fromall1 = changeimports(filestr, 'umath', 'numpy.oldnumeric')
-    filestr, fromall1 = changeimports(filestr, 'Precision', 'numpy.oldnumeric.precision')
-    filestr, fromall1 = changeimports(filestr, 'UserArray', 'numpy.oldnumeric.user_array')
-    filestr, fromall1 = changeimports(filestr, 'ArrayPrinter', 'numpy.oldnumeric.array_printer')
-    filestr, fromall2 = changeimports(filestr, 'numerix', 'numpy.oldnumeric')
-    filestr, fromall3 = changeimports(filestr, 'scipy_base', 'numpy.oldnumeric')
-    filestr, fromall3 = changeimports(filestr, 'Matrix', 'numpy.oldnumeric.matrix')
-    filestr, fromall3 = changeimports(filestr, 'MLab', 'numpy.oldnumeric.mlab')
-    filestr, fromall3 = changeimports(filestr, 'LinearAlgebra', 'numpy.oldnumeric.linear_algebra')
-    filestr, fromall3 = changeimports(filestr, 'RNG', 'numpy.oldnumeric.rng')
-    filestr, fromall3 = changeimports(filestr, 'RNG.Statistics', 'numpy.oldnumeric.rng_stats')
-    filestr, fromall3 = changeimports(filestr, 'RandomArray', 'numpy.oldnumeric.random_array')
-    filestr, fromall3 = changeimports(filestr, 'FFT', 'numpy.oldnumeric.fft')
-    filestr, fromall3 = changeimports(filestr, 'MA', 'numpy.oldnumeric.ma')
+    filestr, fromall1 = changeimports(filestr, 'Numeric', 'oldnumeric')
+    filestr, fromall1 = changeimports(filestr, 'multiarray', 'oldnumeric')
+    filestr, fromall1 = changeimports(filestr, 'umath', 'oldnumeric')
+    filestr, fromall1 = changeimports(filestr, 'Precision', 'oldnumeric.precision')
+    filestr, fromall1 = changeimports(filestr, 'UserArray', 'oldnumeric.user_array')
+    filestr, fromall1 = changeimports(filestr, 'ArrayPrinter', 'oldnumeric.array_printer')
+    filestr, fromall2 = changeimports(filestr, 'numerix', 'oldnumeric')
+    filestr, fromall3 = changeimports(filestr, 'scipy_base', 'oldnumeric')
+    filestr, fromall3 = changeimports(filestr, 'Matrix', 'oldnumeric.matrix')
+    filestr, fromall3 = changeimports(filestr, 'MLab', 'oldnumeric.mlab')
+    filestr, fromall3 = changeimports(filestr, 'LinearAlgebra', 'oldnumeric.linear_algebra')
+    filestr, fromall3 = changeimports(filestr, 'RNG', 'oldnumeric.rng')
+    filestr, fromall3 = changeimports(filestr, 'RNG.Statistics', 'oldnumeric.rng_stats')
+    filestr, fromall3 = changeimports(filestr, 'RandomArray', 'oldnumeric.random_array')
+    filestr, fromall3 = changeimports(filestr, 'FFT', 'oldnumeric.fft')
+    filestr, fromall3 = changeimports(filestr, 'MA', 'oldnumeric.ma')
     fromall = fromall1 or fromall2 or fromall3
     filestr = replaceattr(filestr)
     filestr = replaceother(filestr)
@@ -161,7 +161,7 @@ def fromstr(filestr):
         today = datetime.date.today().strftime('%b %d, %Y')
         name = os.path.split(sys.argv[0])[-1]
         filestr = '## Automatically adapted for '\
-                  'numpy.oldnumeric %s by %s\n\n%s' % (today, name, filestr)
+                  'oldnumeric %s by %s\n\n%s' % (today, name, filestr)
         return filestr, 1
     return filestr, 0
 
@@ -193,7 +193,7 @@ def fromargs(args):
     converttree(filename)
 
 def convertall(direc=os.path.curdir, orig=1):
-    """Convert all .py files to use numpy.oldnumeric (from Numeric) in the directory given
+    """Convert all .py files to use oldnumeric (from Numeric) in the directory given
 
     For each changed file, a backup of <usesnumeric>.py is made as
     <usesnumeric>.py.orig.  A new file named <usesnumeric>.py

--- a/oldnumeric/alter_code2.py
+++ b/oldnumeric/alter_code2.py
@@ -1,5 +1,5 @@
 """
-This module converts code written for numpy.oldnumeric to work
+This module converts code written for oldnumeric to work
 with numpy
 
 FIXME:  Flesh this out.
@@ -25,7 +25,7 @@ from __future__ import division, absolute_import, print_function
 __all__ = []
 
 import warnings
-warnings.warn("numpy.oldnumeric.alter_code2 is not working yet.")
+warnings.warn("oldnumeric.alter_code2 is not working yet.")
 
 import sys
 import os
@@ -78,7 +78,7 @@ def replaceother(astr):
 import datetime
 def fromstr(filestr):
     #filestr = replacetypechars(filestr)
-    filestr, fromall1 = changeimports(filestr, 'numpy.oldnumeric', 'numpy')
+    filestr, fromall1 = changeimports(filestr, 'oldnumeric', 'numpy')
     filestr, fromall1 = changeimports(filestr, 'numpy.core.multiarray', 'numpy')
     filestr, fromall1 = changeimports(filestr, 'numpy.core.umath', 'numpy')
     filestr, fromall3 = changeimports(filestr, 'LinearAlgebra',

--- a/oldnumeric/compat.py
+++ b/oldnumeric/compat.py
@@ -73,7 +73,7 @@ def pickle_array(a):
                 (a.shape, a.dtype.char, a.tostring(), LittleEndian))
 
 def loads(astr):
-    arr = pickle.loads(astr.replace('Numeric', 'numpy.oldnumeric'))
+    arr = pickle.loads(astr.replace('Numeric', 'oldnumeric'))
     return arr
 
 def load(fp):
@@ -105,7 +105,7 @@ if sys.version_info[0] >= 3:
         #      to do.
         def __init__(self, *a, **kw):
             raise NotImplementedError(
-                "numpy.oldnumeric.Unpickler is not supported on Python 3")
+                "oldnumeric.Unpickler is not supported on Python 3")
 else:
     class Unpickler(pickle.Unpickler):
         def load_array(self):

--- a/oldnumeric/fix_default_axis.py
+++ b/oldnumeric/fix_default_axis.py
@@ -121,14 +121,14 @@ def _add_axis(fstr, name, repl):
 def _import_change(fstr, names):
     # Four possibilities
     #  1.) import numpy with subsequent use of numpy.<name>
-    #        change this to import numpy.oldnumeric as numpy
+    #        change this to import oldnumeric as numpy
     #  2.) import numpy as XXXX with subsequent use of
-    #        XXXX.<name> ==> import numpy.oldnumeric as XXXX
+    #        XXXX.<name> ==> import oldnumeric as XXXX
     #  3.) from numpy import *
     #        with subsequent use of one of the names
     #  4.) from numpy import ..., <name>, ... (could span multiple
     #        lines.  ==> remove all names from list and
-    #        add from numpy.oldnumeric import <name>
+    #        add from oldnumeric import <name>
 
     num = 0
     # case 1
@@ -142,7 +142,7 @@ def _import_change(fstr, names):
                 found = 1
                 break
         if found:
-            fstr = "%s%s%s" % (fstr[:ind], "import numpy.oldnumeric as numpy",
+            fstr = "%s%s%s" % (fstr[:ind], "import oldnumeric as numpy",
                                fstr[ind+len(importstr):])
             num += 1
 
@@ -161,7 +161,7 @@ def _import_change(fstr, names):
                 importstr = "import numpy as %s" % module
                 ind = fstr.find(importstr)
                 fstr = "%s%s%s" % (fstr[:ind],
-                                   "import numpy.oldnumeric as %s" % module,
+                                   "import oldnumeric as %s" % module,
                                    fstr[ind+len(importstr):])
                 num += 1
 
@@ -177,7 +177,7 @@ def _import_change(fstr, names):
                 break
         if found:
             fstr = "%s%s%s" % (fstr[:ind],
-                               "from numpy.oldnumeric import *",
+                               "from oldnumeric import *",
                                fstr[ind+len(importstr):])
             num += 1
 
@@ -214,7 +214,7 @@ def _import_change(fstr, names):
                    (fstr[:ind],
                     "from numpy import %s" % \
                     ", ".join(importnames),
-                    "from numpy.oldnumeric import %s" % \
+                    "from oldnumeric import %s" % \
                     ", ".join(addnames),
                     fstr[ptr:])
             num += 1

--- a/oldnumeric/matrix.py
+++ b/oldnumeric/matrix.py
@@ -7,9 +7,9 @@ __all__ = ['UserArray', 'squeeze', 'Matrix', 'asarray', 'dot', 'k', 'Numeric', '
 
 import types
 from .user_array import UserArray, asarray
-import numpy.oldnumeric as Numeric
-from numpy.oldnumeric import dot, identity, multiply
-import numpy.oldnumeric.linear_algebra as LinearAlgebra
+import oldnumeric as Numeric
+from oldnumeric import dot, identity, multiply
+import oldnumeric.linear_algebra as LinearAlgebra
 from numpy import matrix as Matrix, squeeze
 
 # Hidden names that will be the same.

--- a/oldnumeric/mlab.py
+++ b/oldnumeric/mlab.py
@@ -9,8 +9,8 @@ __all__ = ['rand', 'tril', 'trapz', 'hanning', 'rot90', 'triu', 'diff', 'angle',
            'max', 'blackman', 'corrcoef', 'bartlett', 'eye', 'squeeze', 'sinc',
            'tri', 'cov', 'svd', 'min', 'median', 'fliplr', 'eig', 'mean']
 
-import numpy.oldnumeric.linear_algebra as LinearAlgebra
-import numpy.oldnumeric.random_array as RandomArray
+import oldnumeric.linear_algebra as LinearAlgebra
+import oldnumeric.random_array as RandomArray
 from numpy import tril, trapz as _Ntrapz, hanning, rot90, triu, diff, \
      angle, roots, ptp as _Nptp, kaiser, cumprod as _Ncumprod, \
      diag, msort, prod as _Nprod, std as _Nstd, hamming, flipud, \

--- a/oldnumeric/rng.py
+++ b/oldnumeric/rng.py
@@ -1,6 +1,6 @@
 """Re-create the RNG interface from Numeric.
 
-Replace import RNG with import numpy.oldnumeric.rng as RNG.
+Replace import RNG with import oldnumeric.rng as RNG.
 It is for backwards compatibility only.
 
 """

--- a/oldnumeric/rng_stats.py
+++ b/oldnumeric/rng_stats.py
@@ -2,7 +2,7 @@ from __future__ import division, absolute_import, print_function
 
 __all__ = ['average', 'histogram', 'standardDeviation', 'variance']
 
-import numpy.oldnumeric as Numeric
+import oldnumeric as Numeric
 
 def average(data):
     data = Numeric.array(data)

--- a/oldnumeric/user_array.py
+++ b/oldnumeric/user_array.py
@@ -1,9 +1,9 @@
 from __future__ import division, absolute_import, print_function
 
-from numpy.oldnumeric import *
+from oldnumeric import *
 from numpy.lib.user_array import container as UserArray
 
-import numpy.oldnumeric as nold
+import oldnumeric as nold
 __all__ = nold.__all__[:]
 __all__ += ['UserArray']
 del nold

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -10,7 +10,6 @@ class TestRegression(unittest.TestCase):
         from oldnumeric.random_array import randint
         randint(0, 50, [2, 3])
 
-    @pytest.mark.xfail
     def test_mlab_import(self):
         """gh-3803"""
         try:


### PR DESCRIPTION
Since `oldnumeric` is now a standalone package, all references to `numpy.oldnumeric` must become `oldnumeric`.